### PR TITLE
fix for the VERSION file issue

### DIFF
--- a/src/ansys/api/meshing/prime/__init__.py
+++ b/src/ansys/api/meshing/prime/__init__.py
@@ -1,9 +1,3 @@
 import os
 
-__all__ = ['__version__']
-# Get version from version info
-HERE = os.path.abspath(os.path.dirname(__file__))
-__version__ = None
-version_file = os.path.join(HERE, 'VERSION')
-with open(version_file, mode='r') as fd:
-    __version__ = fd.read().strip()
+from ansys.api.meshing.prime._version import __version__

--- a/src/ansys/api/meshing/prime/_version.py
+++ b/src/ansys/api/meshing/prime/_version.py
@@ -1,0 +1,26 @@
+"""Version of ansys-api-meshing-prime library.
+
+On the ``main`` branch, use 'dev0' to denote a development version.
+For example:
+
+version_info = 0, 1, 0, 'dev0'
+
+Examples
+--------
+Print the version
+
+>>> from ansys.product import library
+>>> print(library.__version__)
+0.1.4
+
+"""
+
+# major, minor, patch
+version_info = 0, 1, 4
+
+# Nice string for the version
+__version__ = '.'.join(map(str, version_info))
+
+# Write the version string to a file
+with open('VERSION', 'w') as version_file:
+    version_file.write(__version__)


### PR DESCRIPTION
Do the same as in prime meshing, 

In addition generate the VERSION file as well ,so that it can be used elsewhere as before.